### PR TITLE
Add examples to check properties of query samplers

### DIFF
--- a/cardinal/plotting.py
+++ b/cardinal/plotting.py
@@ -39,3 +39,20 @@ def plot_confidence_interval(*args, label=None, q_inf=0.1, q_sup=0.9, alpha=.3, 
         plt.scatter(x_data, avg, c=color)
 
     plt.fill_between(x_plot, q90_plot, q10_plot, color=color, alpha=alpha)
+
+
+def smooth_line(line, smoothing=10, k=2):
+    x = line.get_xdata()
+    y = line.get_ydata()
+    x_plot = np.linspace(x.min(), x.max(), x.shape[0] * smoothing) 
+    y_plot = make_interp_spline(x, y, k=k)(x_plot)
+    line.set_xdata(x_plot)
+    line.set_ydata(y_plot)
+
+
+def smooth_lines(axis=None, smoothing=10, k=2):
+    if axis is None:
+        axis = plt.gca()
+    
+    for line in axis.lines:
+        smooth_line(line, smoothing=smoothing, k=k)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,8 @@ import cardinal
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'matplotlib.sphinxext.mathmpl',
+    'matplotlib.sphinxext.plot_directive',
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',

--- a/examples/properties/README.rst
+++ b/examples/properties/README.rst
@@ -1,0 +1,3 @@
+# Properties
+
+These examples test the behavior of samplers in peculiar synthetic settings.

--- a/examples/properties/plot_isolated_cluster.py
+++ b/examples/properties/plot_isolated_cluster.py
@@ -12,7 +12,7 @@ explore the dataset well enough through diversity or representativity
 sampling.
 """
 
-from copy import copy
+from copy import deepcopy
 
 import numpy as np
 from sklearn.datasets import make_blobs
@@ -41,7 +41,7 @@ clf = LogisticRegression()
 # first two blobs. This simulates an unlucky initialization where no data
 # from the isolated cluster is selected.
 
-init_spl = ActiveLearningSplitter(X.shape[0], test_size=0.2, stratify=blob)
+init_spl = ActiveLearningSplitter(X.shape[0], test_size=0.2, stratify=blob, random_state=0)
 init_spl.add_batch(np.hstack([
     np.where(blob[init_spl.train] == 0)[0][:batch_size],
     np.where(blob[init_spl.train] == 1)[0][:batch_size]
@@ -58,26 +58,13 @@ plt.text(4, 3.2, 'Isolated cluster', ha='center', c='r')
 plt.legend()
 plt.axis('off')
 
-##############################################################################
-# We create figure to track both the global accuracy and the accuracy on the
-# isolated cluster only.
-
-plt.figure()
-g_ax = plt.gca()
-plt.ylabel('Global accuracy')
-plt.xlabel('Iteration')
-
-plt.figure()
-ic_ax = plt.gca()
-plt.ylabel('Isolated cluster accuracy')
-plt.xlabel('Iteration')
-
+plt.show()
 
 ##############################################################################
-# This function runs the experiment? It is a class active learning setting.
+# This function runs the experiment. It is a class active learning setting.
 
-def evaluate(name, sampler):
-    spl = copy(init_spl)
+def evaluate(name, sampler, g_ax, ic_ax):
+    spl = deepcopy(init_spl)
     g_acc = []
     ic_acc = []
 
@@ -91,7 +78,6 @@ def evaluate(name, sampler):
     g_ax.plot(np.arange(10), g_acc, label=name)
     ic_ax.plot(np.arange(10), ic_acc, label=name)
 
-
 ##############################################################################
 # We now display the results for 3 very common samplers. You may observe that
 # the confidence sampling completely ignores the isolated cluster since it
@@ -99,11 +85,23 @@ def evaluate(name, sampler):
 # a 15% chance of picking a sample in this cluster during the experiment. By
 # design, KMeans sampling will always select samples in the isolated cluster!
 
-evaluate('Confidence Sampler', ConfidenceSampler(clf, batch_size=batch_size, assume_fitted=True))
-evaluate('Random Sampler', RandomSampler(batch_size=batch_size, random_state=0))
-evaluate('KMeans Sampler', KMeansSampler(batch_size=batch_size))
+plt.figure()
+global_ax = plt.gca()
+plt.ylabel('Global accuracy')
+plt.xlabel('Iteration')
 
-g_ax.legend()
-smooth_lines(axis=g_ax, k=2)
-ic_ax.legend()
-smooth_lines(axis=ic_ax, k=2)
+plt.figure()
+isolated_cluster_ax = plt.gca()
+plt.ylabel('Isolated cluster accuracy')
+plt.xlabel('Iteration')
+
+evaluate('Confidence Sampler', ConfidenceSampler(clf, batch_size=batch_size, assume_fitted=True), global_ax, isolated_cluster_ax)
+evaluate('Random Sampler', RandomSampler(batch_size=batch_size, random_state=0), global_ax, isolated_cluster_ax)
+evaluate('KMeans Sampler', KMeansSampler(batch_size=batch_size), global_ax, isolated_cluster_ax)
+
+global_ax.legend()
+smooth_lines(axis=global_ax, k=2)
+isolated_cluster_ax.legend()
+smooth_lines(axis=isolated_cluster_ax, k=2)
+
+plt.show()

--- a/examples/properties/plot_isolated_cluster.py
+++ b/examples/properties/plot_isolated_cluster.py
@@ -1,0 +1,109 @@
+
+"""
+Isolated cluster and bad init
+=============================
+
+The iterative process of Active Learning may induce corner cases that
+are proper to Active Learning. In this case, we look at what happens if
+some data has an isolated cluster where no point is selected at init.
+
+This cluster may be totally overlooked by some samplers that do not
+explore the dataset well enough through diversity or representativity
+sampling.
+"""
+
+from copy import copy
+
+import numpy as np
+from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from matplotlib import pyplot as plt
+
+from cardinal.utils import ActiveLearningSplitter
+from cardinal.uncertainty import ConfidenceSampler
+from cardinal.random import RandomSampler
+from cardinal.clustering import KMeansSampler
+from cardinal.plotting import smooth_lines
+
+
+##############################################################################
+# We simulate two classes. Class 0 is simply a large blob. Class 1 is composed
+# of a large blob and an isolated cluster located aside. In order to generate
+# this cluster, the data for this class is seperated into two blobs.
+X, blob = make_blobs([500, 400, 100], centers=[(2, 0), (-2, 0), (4, 5)], cluster_std=[1.0, 1.0, 0.3], random_state=0)
+batch_size = 10
+clf = LogisticRegression()
+
+##############################################################################
+# We now create the active learning experiment. We use cardinal's splitter
+# to handles indices. For the initialisation, we only sample data from the
+# first two blobs. This simulates an unlucky initialization where no data
+# from the isolated cluster is selected.
+
+init_spl = ActiveLearningSplitter(X.shape[0], test_size=0.2, stratify=blob)
+init_spl.add_batch(np.hstack([
+    np.where(blob[init_spl.train] == 0)[0][:batch_size],
+    np.where(blob[init_spl.train] == 1)[0][:batch_size]
+]))
+left_out_y = (blob[init_spl.test] == 2)
+y = blob.copy()
+y[blob == 2] = 1
+
+plt.scatter(X[:, 0], X[:, 1], c=['C{}'.format(i) for i in y], alpha=.3)
+plt.scatter(X[init_spl.selected, 0], X[init_spl.selected, 1], facecolors='none', edgecolors='r', linewidth=2, label='Init batch')
+plt.gca().add_patch(plt.Circle((4, 5), 1.2, color='r', fill=False, linestyle='dashed', linewidth=2))
+plt.text(4, 3.2, 'Isolated cluster', ha='center', c='r')
+
+plt.legend()
+plt.axis('off')
+
+##############################################################################
+# We create figure to track both the global accuracy and the accuracy on the
+# isolated cluster only.
+
+plt.figure()
+g_ax = plt.gca()
+plt.ylabel('Global accuracy')
+plt.xlabel('Iteration')
+
+plt.figure()
+ic_ax = plt.gca()
+plt.ylabel('Isolated cluster accuracy')
+plt.xlabel('Iteration')
+
+
+##############################################################################
+# This function runs the experiment? It is a class active learning setting.
+
+def evaluate(name, sampler):
+    spl = copy(init_spl)
+    g_acc = []
+    ic_acc = []
+
+    for _ in range(10):
+        clf.fit(X[spl.selected], y[spl.selected])
+        sampler.fit(X[spl.selected], y[spl.selected])
+        spl.add_batch(sampler.select_samples(X[spl.non_selected]))
+        g_acc.append(accuracy_score(y[spl.test], clf.predict(X[spl.test])))
+        ic_acc.append(accuracy_score(y[spl.test][left_out_y], clf.predict(X[spl.test][left_out_y])))
+    
+    g_ax.plot(np.arange(10), g_acc, label=name)
+    ic_ax.plot(np.arange(10), ic_acc, label=name)
+
+
+##############################################################################
+# We now display the results for 3 very common samplers. You may observe that
+# the confidence sampling completely ignores the isolated cluster since it
+# is designed to focus on the existing decision boundary. Random sampling has
+# a 15% chance of picking a sample in this cluster during the experiment. By
+# design, KMeans sampling will always select samples in the isolated cluster!
+
+evaluate('Confidence Sampler', ConfidenceSampler(clf, batch_size=batch_size, assume_fitted=True))
+evaluate('Random Sampler', RandomSampler(batch_size=batch_size, random_state=0))
+evaluate('KMeans Sampler', KMeansSampler(batch_size=batch_size))
+
+g_ax.legend()
+smooth_lines(axis=g_ax, k=2)
+ic_ax.legend()
+smooth_lines(axis=ic_ax, k=2)

--- a/examples/properties/plot_noisy_boundary.py
+++ b/examples/properties/plot_noisy_boundary.py
@@ -1,0 +1,114 @@
+
+"""
+Noisy boundary
+==============
+
+Can a noisy boundary tamper with an active learning process? For this test,
+we select a very simple classification problem. However, this problem is made
+more difficult by the existence of a noisy boundary where samples are
+indistinguishable from each other. Let us see if this samplers fall for this
+"honey pot".
+"""
+
+from copy import deepcopy
+
+import numpy as np
+from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from matplotlib import pyplot as plt
+
+from cardinal.utils import ActiveLearningSplitter
+from cardinal.uncertainty import ConfidenceSampler
+from cardinal.random import RandomSampler
+from cardinal.clustering import KMeansSampler
+from cardinal.plotting import smooth_lines
+
+
+##############################################################################
+# We simulate two classes. Each class is composed of two blobs. One is clearly
+# distinct for each class, and one is located in a very noisy areas where
+# classes mix with each other.
+seed = 2
+X_noisy, y_noisy = make_blobs([250, 250], centers=[(0, 0), (0, 0)], cluster_std=[0.3, 0.3], random_state=seed)
+X_large, y_large = make_blobs([250, 250], centers=[(-4, 0), (4, 0)], cluster_std=[2, 2], random_state=seed)
+X_large[:, 1] *= 5
+batch_size = 10
+clf = LogisticRegression()
+X = np.vstack([X_noisy, X_large])
+y = np.hstack([y_noisy, y_large])
+
+##############################################################################
+# We now create the active learning experiment. We use cardinal's splitter
+# to handles indices. For the initialisation, We sample data in all blobs.
+
+init_spl = ActiveLearningSplitter(X.shape[0], test_size=0.2, shuffle=True, stratify=y, random_state=seed)
+
+init_random_spl = deepcopy(init_spl)
+np.random.seed(seed)
+init_random_spl.add_batch(np.hstack([
+    np.random.choice(np.where(y[init_spl.train] == 0)[0], size=batch_size),
+    np.random.choice(np.where(y[init_spl.train] == 1)[0], size=batch_size),
+]))
+
+init_noisy_spl = deepcopy(init_spl)
+init_noisy_spl.add_batch(np.hstack([
+    np.where(y[init_spl.train] == 0)[0][:batch_size],
+    np.where(y[init_spl.train] == 1)[0][:batch_size],
+]))
+
+
+plt.scatter(X[:, 0], X[:, 1], c=['C{}'.format(i) for i in y], alpha=.3)
+plt.scatter(X[init_random_spl.selected, 0], X[init_random_spl.selected, 1], facecolors='none', edgecolors='r', linewidth=2, label='Random init batch')
+plt.scatter(X[init_noisy_spl.selected, 0], X[init_noisy_spl.selected, 1], facecolors='none', edgecolors='b', linewidth=2, label='Noisy init batch')
+
+plt.legend()
+plt.axis('off')
+
+plt.show()
+
+
+##############################################################################
+# This function runs the experiment. It is a class active learning setting.
+
+def evaluate(name, sampler, init_spl, ax):
+    spl = deepcopy(init_spl)
+    g_acc = []
+
+    for _ in range(10):
+        clf.fit(X[spl.selected], y[spl.selected])
+        sampler.fit(X[spl.selected], y[spl.selected])
+        spl.add_batch(sampler.select_samples(X[spl.non_selected]))
+        g_acc.append(accuracy_score(y[spl.test], clf.predict(X[spl.test])))
+    
+    ax.plot(np.arange(10), g_acc, label=name)
+
+##############################################################################
+# We create a figure to track both the global accuracy with random and noisy
+# initialization and display the results for 3 very common samplers.
+plt.figure()
+gr_ax = plt.gca()
+plt.ylabel('Global accuracy with random init')
+plt.xlabel('Iteration')
+
+plt.figure()
+gn_ax = plt.gca()
+plt.ylabel('Global accuracy with noisy init')
+plt.xlabel('Iteration')
+
+evaluate('Confidence Sampler', ConfidenceSampler(clf, batch_size=batch_size, assume_fitted=True), init_random_spl, gr_ax)
+evaluate('Random Sampler', RandomSampler(batch_size=batch_size, random_state=0), init_random_spl, gr_ax)
+evaluate('KMeans Sampler', KMeansSampler(batch_size=batch_size), init_random_spl, gr_ax)
+
+gr_ax.legend()
+smooth_lines(axis=gr_ax, k=2)
+
+evaluate('Confidence Sampler', ConfidenceSampler(clf, batch_size=batch_size, assume_fitted=True), init_noisy_spl, gn_ax)
+evaluate('Random Sampler', RandomSampler(batch_size=batch_size, random_state=0), init_noisy_spl, gn_ax)
+evaluate('KMeans Sampler', KMeansSampler(batch_size=batch_size), init_noisy_spl, gn_ax)
+
+gn_ax.legend()
+smooth_lines(axis=gn_ax, k=2)
+
+
+plt.show()


### PR DESCRIPTION
This PR adds two examples in a "Properties" section to check how samplers behave in two situations:
- when an isolated cluster lies in the data (diversity / representativeness)
- when the decision boundary is very noisy and acts as a "honey pot" for uncertainty based sampling.